### PR TITLE
fix: Fix mismatch in positional arguments by using keyword arguments

### DIFF
--- a/patho_bench/ExperimentFactory.py
+++ b/patho_bench/ExperimentFactory.py
@@ -134,16 +134,16 @@ class ExperimentFactory:
             model_kwargs: dict, additional arguments to pass to the model constructor. Only needed if pooled_embeddings_dir is empty.
             num_bootstraps: int, number of bootstraps. Default is 100.
         '''
-        _, task_info, internal_dataset = ExperimentFactory._prepare_internal_dataset(split,
-                                                                                    task_config,
-                                                                                    saveto,
-                                                                                    combine_slides_per_patient,
-                                                                                    COMBINE_TRAIN_VAL,
-                                                                                    patch_embeddings_dirs,
-                                                                                    pooled_embeddings_dir,
-                                                                                    model_name,
-                                                                                    model_kwargs,
-                                                                                    gpu)
+        _, task_info, internal_dataset = ExperimentFactory._prepare_internal_dataset(split_path=split,
+                                                                                    task_config=task_config,
+                                                                                    saveto=saveto,
+                                                                                    combine_slides_per_patient=combine_slides_per_patient,
+                                                                                    combine_train_val=COMBINE_TRAIN_VAL,
+                                                                                    patch_embeddings_dirs=patch_embeddings_dirs,
+                                                                                    pooled_embeddings_dir=pooled_embeddings_dir,
+                                                                                    model_name=model_name,
+                                                                                    model_kwargs=model_kwargs,
+                                                                                    gpu=gpu)
         
         # Initialize experiment
         experiment = RetrievalExperiment(
@@ -206,16 +206,16 @@ class ExperimentFactory:
             model_kwargs: dict, additional arguments to pass to the model constructor. Only needed if pooled_embeddings_dir is empty.
             num_bootstraps: int, number of bootstraps. Default is 100.
         '''
-        _, task_info, internal_dataset = ExperimentFactory._prepare_internal_dataset(split,
-                                                                                    task_config,
-                                                                                    saveto,
-                                                                                    combine_slides_per_patient,
-                                                                                    COMBINE_TRAIN_VAL,
-                                                                                    patch_embeddings_dirs,
-                                                                                    pooled_embeddings_dir,
-                                                                                    model_name,
-                                                                                    model_kwargs,
-                                                                                    gpu)
+        _, task_info, internal_dataset = ExperimentFactory._prepare_internal_dataset(split_path=split,
+                                                                                    task_config=task_config,
+                                                                                    saveto=saveto,
+                                                                                    combine_slides_per_patient=combine_slides_per_patient,
+                                                                                    combine_train_val=COMBINE_TRAIN_VAL,
+                                                                                    patch_embeddings_dirs=patch_embeddings_dirs,
+                                                                                    pooled_embeddings_dir=pooled_embeddings_dir,
+                                                                                    model_name=model_name,
+                                                                                    model_kwargs=model_kwargs,
+                                                                                    gpu=gpu)
         
         # Initialize experiment
         experiment = CoxNetExperiment(
@@ -295,13 +295,14 @@ class ExperimentFactory:
         assert batch_size == 1, 'Only batch_size = 1 is supported for finetuning for now'
         
         ###### Get dataset ################################################################
-        split, task_info, internal_dataset = ExperimentFactory._prepare_internal_dataset(split,
-                                                                                    task_config,
-                                                                                    saveto,
-                                                                                    combine_slides_per_patient,
-                                                                                    COMBINE_TRAIN_VAL,
-                                                                                    patch_embeddings_dirs,
-                                                                                    bag_size = bag_size)
+        split, task_info, internal_dataset = ExperimentFactory._prepare_internal_dataset(split_path=split,
+                                                                                    task_config=task_config,
+                                                                                    saveto=saveto,
+                                                                                    combine_slides_per_patient=combine_slides_per_patient,
+                                                                                    combine_train_val=COMBINE_TRAIN_VAL,
+                                                                                    patch_embeddings_dirs=patch_embeddings_dirs,
+                                                                                    gpu=gpu,
+                                                                                    bag_size=bag_size)
         
         task_name = task_info['task_col']
 


### PR DESCRIPTION
The `gpu` arg taken in by the multiple experiment methods in the `ExperimentFactory` was being passed to the `bag_size` arg of `_prepare_internal_dataset()` method due to a mismatch in positional arguments.